### PR TITLE
add bind to CrystalFTP

### DIFF
--- a/src/CrystalFTP.cr
+++ b/src/CrystalFTP.cr
@@ -82,6 +82,12 @@ module CrystalFTP
       end
     end
 
+    # Starting the FTP server, making clients able to connect and communicate with it
+    def bind
+      @logger.info "FTP server started, rooted at #{@root} and listening on port #{@port}..."
+      loop &->accept_client
+    end
+
     # Change the level of severity beyond which the logger of your `FTPServer` will print logs
     #
     # NOTE: When building in release mode, the severity is by default at Logger::ERROR. Otherwise, it is set by default at Logger::INFO


### PR DESCRIPTION
this adds a `#bind` function to the base module.
This is if you just want to use the server and not have it in a Fiber.

example
```crystal
  server = FTPServer.new(port: port.to_i, root: root)
  server.verbose_level = Logger::DEBUG
  server.bind
```